### PR TITLE
Rename driver to client for the marionette installation, to follow bug 1246407

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -79,7 +79,7 @@ pip install -U setuptools
 cd $WORKSPACE/mozbase
 python setup_development.py
 
-cd $WORKSPACE/marionette/driver
+cd $WORKSPACE/marionette/client
 python setup.py install
 
 cd $WORKSPACE/marionette


### PR DESCRIPTION
Simple rename, seems to work locally.

This should fix at least some of the current bustage (I believe there's other actual test bustage happening as well atm).
