### PR TITLE
Bug 1248960 - Transition the functional tests to run standalone from the new loop repo, rather than the old loop-client one.

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -64,6 +64,7 @@ cp ${KEY_FILE} $WORKSPACE/loop-server/config/
 
 cd $WORKSPACE/loop-standalone
 npm install
+make build
 
 cd $WORKSPACE
 virtualenv venv


### PR DESCRIPTION
@nils-ohlmeier this needs to be combined with a transition to make the standalone use the new loop repo. More details in the [bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1248960).
